### PR TITLE
acpiexamples: rename ExecuteOSI to ExecuteExampleOSI to avoid redecla…

### DIFF
--- a/generate/unix/Makefile.config
+++ b/generate/unix/Makefile.config
@@ -35,7 +35,7 @@
 .SUFFIXES :
 PROGS = acpibin acpidump acpiexamples acpiexec acpihelp acpinames acpisrc acpixtract iasl
 HOST ?= _CYGWIN
-CC =    gcc
+CC ?=    gcc
 
 #
 # Common defines


### PR DESCRIPTION
…ration error

Recent changes in the acpiexec files inserted the ExecuteOSI function prototype
within aecommon.h. This file is included by acpiexamples and acpiexamples contains
a statically defined function called ExecuteOSI within examples.c. This change
fixes the compilation error intoduced by changes within aecommon.h.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>